### PR TITLE
Cn prototype

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,9 @@
 'use strict';
 
 module.exports = {
-	extends: 'ckeditor5'
+  extends: 'ckeditor5',
+  env: {
+    'browser': true,
+    'node': true
+  }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@ckeditor/ckeditor5-essentials": "^11.0.1",
     "@ckeditor/ckeditor5-heading": "^11.0.1",
     "@ckeditor/ckeditor5-image": "^13.0.1",
+    "@ckeditor/ckeditor5-inspector": "^1.3.0",
     "@ckeditor/ckeditor5-link": "^11.0.1",
     "@ckeditor/ckeditor5-list": "^12.0.1",
     "@ckeditor/ckeditor5-media-embed": "^11.1.0",
@@ -86,5 +87,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "dependencies": {
+    "@ckeditor/ckeditor5-widget": "^11.0.1"
   }
 }

--- a/sample/index.html
+++ b/sample/index.html
@@ -2,40 +2,192 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
-	<title>CKEditor 5 – classic editor build – development sample</title>
-	<style>
+  <title>CKEditor 5 – classic editor build – development sample</title>
+  <style>
 		body {
 			max-width: 800px;
 			margin: 20px auto;
 		}
-	</style>
+    block-quote, block-quote-body, block-quote-credit, para-box {
+      display: block;
+    }
+  </style>
 </head>
 <body>
 
 <h1>CKEditor 5 – classic editor build – development sample</h1>
 
 <div id="editor">
-	<h2>Sample</h2>
+  <para-box>
+    <p>
+      This is some text in a parallax container.
+    </p>
+    </para-box>
+  <p>JEFF NICHOLS SAT in the dark, listening. It was 2015, just after New Year’s, and the writer-director was completing a mix inside a cavernous dubbing stage on the Warner Bros. lot in Burbank, California. Nichols and his team were in the process of weaving hundreds of tracks of dialog, music, and sound effects to create the aural backdrop for his fourth film, a sci-fi thriller called <i>Midnight Special</i>. An explosion was “too wonky,” the music “a little too hot.” Moviegoers can only truly register so many elements at once, Nichols said. “You don’t want to highlight the way it’s put together. You want it to be experiential. <i>Moving</i>.”</p>
+  <p>If you had to choose two adjectives to describe Nichols’ earlier three films, you could do worse than <i>experiential</i> and <i>moving</i>. His debut, 2007’s <i>Shotgun Stories</i>, was a revenge story filled with foreboding. His next film, 2011’s <i>Take Shelter</i>, was a paranoid, apocalyptic tale that explored what a man will do to protect the ones he loves. Then came <i>Mud</i>, in 2012, a coming-of-age story built around two boys’ discovery of a fugitive (Matthew McConaughey) living on an island in the middle of the Mississippi River.</p>
+  <p>All three films had been acclaimed but, as Nichols acknowledged, “underseen.” He had resolved not to let this happen again, which is why he was here, in this tricked-out dubbing stage—the same one, the Arkansas native delighted in pointing out, where another one-time indie darling, Christopher Nolan, had mixed his 2014 blockbuster <i>Interstellar</i>. If Nichols had anything to say about it, <i>Midnight Special</i>would do better than any of his other movies and be a stepping-stone to something even bigger. To <i>experiential</i> and <i>moving</i>, Nichols wanted to add <i>blockbusting</i>.</p>
+  <p>A few more tweaks and Nichols announced it was time for a break. Blinking as we stepped into the bright LA sunshine, we headed for the studio’s commissary. We took our burgers to a picnic table outside, and as soon as we sat down, Nichols’ usually voluble Little Rock twang dropped to a whisper. “Wow!” he hissed, his eyes locked on a gray-haired, lanky guy about 100 feet away. “There’s Clint Eastwood! Right there!” I looked, and, yep, there he was.</p>
+  <p>“Oh, man, that’s rad,” Nichols said, giddy as any fan. “I’ve eaten here, like, a million times, and I’ve never seen anyone famous.”</p>
+  <block-quote position="inset-left">
+    <block-quote-body>
+      <p>The path from Southern Gothic indies to superheroes isn’t an obvious one—and not one that everybody with the film-school cred of Nichols would want to walk.</p>
+    </block-quote-body>
+    <block-quote-credit>
+      <p>credit</p>
+    </block-quote-credit>
+  </block-quote>
+  <p>This felt like more than a star sighting. At 85, Eastwood is a movie icon and Warner Bros.’ longest-reigning auteur, having made 37 films there over 45 years. His no-­nonsense directing style is something that Nichols consciously emulates. It was hard not to see Dirty Harry’s walk-on cameo as some sort of an omen. “Nobody effs with Clint Eastwood!” Nichols said. “Anywhere, much less here.”</p>
+  <p>He took another bite of hamburger as we talked directors. “There’s a short roster of people who can step in and direct these $100 million and $200 million films,” Nichols said.</p>
+  <p>Did he want to be on that short list? “If it’s good, and if I’m given enough rope to hang myself, totally!”</p>
+  <p>Little by little, strategic decision by strategic decision, Nichols has been preparing to make not <i>this</i> movie so much as the <i>next</i> one or perhaps the one after that. At a distinctly unwhopping $23 million, <i>Midnight Special</i>’s budget is more than twice as big as those of his first three movies combined. This film is about a boy with extraordinary powers on the run across the South with his dad, with special effects and car chases and a real live marketing budget from a real live movie studio—Warner Bros., a place where auteur directors, from Eastwood to Nolan, take on giant projects.</p>
+  <p>The path from Southern Gothic indies to superheroes isn’t an obvious one, though—and not one that everybody with the film-school cred of Nichols would want to walk. But he does, even if the things that make Nichols a great director might mean he won’t get the chance.</p>
+  <p>Don’t worry, though. Jeff Nichols has a plan.</p>
+  <para-box>
+    <figure class="image">
+       <img src="https://www.wired.com/wp-content/uploads/2016/02/jeffnichols11.jpg">
+       <figcaption>“There’s one right place to put the camera,” <i>Nichols</i> says. “I’m a big believer in that.”</figcaption>
+    </figure>
+  </para-box>
+  <h3>June 2004 Little Rock, Arkansas</h3>
+  <p>Nichols wrote the script for his first movie, <i>Shotgun Stories</i>, with an actor in mind: Michael Shannon. They’d never met, but after seeing Shannon in <a href="https://youtu.be/0ShWGyC408I"><i>8 Mile</i></a> and <i>High Crimes</i>, Nichols decided he wanted him in every movie he would ever make. Through a former professor, Nichols—then just 24—tracked Shannon down and persuaded him to read the script. “Your agent’s always telling you, don’t work with first-time directors, work with somebody who knows what they’re doing,” Shannon told me. “But I got the impression from Jeff the first time I talked to him that he knew what he was doing.”</p>
+  <p>That’s because Nichols has been thinking about movies for a long time. His dad and uncle own a furniture store in Little Rock. But during off-hours, when most dads might take their sons fishing, Nichols’ dad would take Jeff to the multiplex. Nichols loved John Carpenter, Steven Spielberg, John Sayles, Ridley Scott, and “anything with Paul Newman in it.” He read a lot too—S. E. Hinton, the master of young-adult fiction, made a huge impression, especially with <i>The Outsiders</i> and <i>Rumble Fish</i>. (Motorcycle Boy has “the best name ever,” Nichols said.)</p>
+  <p>Nichols studied filmmaking at the University of North Carolina School of the Arts, which he describes as more like a trade school in that it stresses skills over theory. Before Nichols wrote his first screenplay, he told his father that it would be about New York mobsters. Gently, his dad suggested that, instead, he write about “a place you know that others don’t.” The result was <i>Shotgun Stories</i>, set amid the cotton fields and back roads of southeastern Arkansas.</p>
+  <block-quote>
+    <block-quote-body>
+      <p><i>Shotgun Stories</i> became the beginning of a self-styled curriculum. Nichols set out to teach himself lessons that would let him make bigger movies down the line.</p>
+    </block-quote-body>
+  </block-quote>
+  <p>Shannon signed on and even agreed to work for free. Nichols’ mom cooked for the crew, and his dad ferried people to and from the set. At one point, Nichols realized he was going to run out of celluloid—“it was costing me and my family $365 a minute every time we rolled film”—so he cut back on the number of takes. Still, despite the ragtag nature of the production, Shannon was impressed. “I consider Jeff a member of the Southern culture—not necessarily the culture of Nascar-­watching, beer-­drinking people but people like William Faulkner and Flannery O’Connor,” he said.</p>
+  <p>But if Nichols was to become an important voice in the Southern storytelling canon, he still had a lot to learn. Nichols “had a lot of ideas and a lot of charisma, but I think he also still had a lot of uncertainty,” Shannon said, remembering how Nichols pressed him for advice. So <i>Shotgun Stories</i> became the beginning of a self-styled curriculum. Nichols set out to methodically teach himself lessons that would let him make bigger movies down the line.</p>
+  <p>Though he thought the movie was makeable for under $50,000 (“I didn’t move the camera and shot all exteriors during the day”), Nichols had to borrow and scrape to get it done. He wrote the script in his father’s furniture store, “surrounded by mattresses,” and edited it in his laundry room. Lack of money and distribution muscle meant the movie, shot in 2004, didn’t get to theaters until 2007.</p>
+  <para-box>
+    <figure class="image image-style-align-left">
+      <img src="https://www.wired.com/wp-content/uploads/2016/03/jeffnichols_shotgunstories1.png" alt="MIDNIGHT SPECIAL">
+      <figcaption>From left, Michael Shannon, Barlow Jacobs, and Douglas Ligon in a scene from Jeff Nichols’ 2007 film, <i>Shotgun Stories</i>. COURTESY JEFF NICHOLS</figcaption>
+   </figure>
+    <figure class="image image-style-align-right">
+       <img src="https://www.wired.com/wp-content/uploads/2016/03/jeffnichols-MS-016371-660x471.jpg" alt="MIDNIGHT SPECIAL">
+       <figcaption><i>Midnight Special</i> is director Nichols’ biggest film yet. BEN ROTHSTEIN/WARNER BROS. PICTURES</figcaption>
+    </figure>
+  </para-box>
+  <p>After <i>Shotgun Stories</i>, Nichols showed Shannon two finished scripts—<i>Take Shelter</i> and <i>Mud</i>—and asked which he should do next. Shannon said <i>Mud</i>, because he thought the special effects sequences in <i>Take Shelter</i> would be too expensive for a sophomore effort. Politely but firmly, Nichols demurred. He had ideas about how to do the effects on the cheap. (He eventually made the movie for about $900,000.) Besides, Nichols later told me, he’d written <i>Mud</i> for Matthew McConaughey, “and I wasn’t famous enough then to have him return my call.”</p>
+  <p><i>Take Shelter</i>, then, became an all-out effort to get on the radar. At its core, the film, which Nichols wrote as he was starting a family, is about the anxiety that comes with responsibility or having something to lose. But again, Nichols was explicit about using this second film to acquire skills. Having never written a strong woman character, he assigned himself that job. (She’s played in <i>Take Shelter</i> by Jessica Chastain.) And while Nichols knew he needed the festival circuit to promote the film, he intentionally threw in sci-fi touches (think oily rain falling from the sky and swarms of menacing black birds) unusual in indies. The idea was to learn how to use genre as a tool and to show that he was capable of making something ambitious: a crowd-pleaser. In 2011, Nichols brought <i>Take Shelter</i> to the Cannes Film Festival and won the Critics Week Prize.</p>
+  <p>Up to this point, Nichols was proving remarkably capable of directing not just films but his career. Though Nichols had never used a Steadicam, he shot a significant portion of his next movie, <i>Mud,</i> with one—another skill in the toolbox. <i>Mud</i> also proved that Nichols could not only wrangle stars (Reese Witherspoon played McConaughey’s love interest, Juniper) but could help them shine. Nolan has said that he cast McConaughey in <i>Interstellar</i> after seeing him in <i>Mud</i>.</p>
+  <p>By the standards of the indie world, <i>Mud</i> was a hit, a career-maker—nominated for the 2012 Palme d’Or at Cannes, winner of the Robert Altman Award at the Independent Spirit Awards. But Nichols had different standards. He admires Jim Jarmusch but doesn’t want to be him. Because of the paltry distribution deal <i>Mud</i> got from Lionsgate (the studio invested just $1.5 million in marketing, Nichols said, which his financier matched), most people have never heard of it let alone seen it.</p>
+  <p>Nichols was done with that kind of success. He realized that if he wanted to get his movies in front of an audience, he needed the people who control the distribution channels and know how to sell. He needed a studio.</p>
+  <para-box>
+    <figure class="image">
+       <img src="https://www.wired.com/wp-content/uploads/2016/03/nichols_MCDMUDD_EC011_H-11.jpg">
+       <figcaption>Nichols on the Arkansas set of his third film, <i>Mud</i>, with Matthew McConaughey in 2012. JIM BRIDGES/ROADSIDE ATTRACTIONS/EVERETT COLLECTION</figcaption>
+    </figure>
+  </para-box>
+  <h3>February 2014 Southern Louisiana</h3>
+  <p>Jeff Nichols sat facing the wind, watching. He and about half his 150-person crew had been on this gravel-strewn logging road in the Big Branch Marsh National Wildlife Refuge, about 45 minutes north of New Orleans, since dawn. It was day 30 of production on <i>Midnight Special</i>, and the winter had been one of the coldest in Louisiana’s history. Even though the sun was out, everyone was hunched in parkas.</p>
+  <p>Looking at the director—clear-eyed and stubble-faced in gray jeans, brown work boots, a red-and-blue plaid shirt under a navy V-neck sweater—you wouldn’t sense any jitters. He joked easily with his cast and crew while projecting an air of knowing precisely what he wanted. “You never really have a question for him that he can’t answer,” Joel Edgerton, who plays a state trooper in the film, told me between takes. “I presume if you hid a GoPro in the corner of the room where he writes, he probably runs around and acts it all out.”</p>
+  <block-quote>
+    <block-quote-body>
+      <p>“I never wanted to make movies just for me,” Nichols says. “I want to make movies that people watch.”</p>
+    </block-quote-body>
+  </block-quote>
+  <p>Indeed, Nichols said, while on set he sees the whole movie in his mind’s eye, at least as he imagined it while writing the script. But directing is “a weird job,” he said, because it requires “this constant balance between the original idea and the fluidity on set. I work really hard on these scripts. I don’t take changes lightly. But I know there has to be a balance.”</p>
+  <p>The day’s scene involved all of Nichols’ main cast members—Edgerton, Shannon, Adam Driver (playing a federal agent), 13-year-old Jaeden Lieberher (who plays Alton, a mysterious glowing-eyed boy), and Kirsten Dunst (as Alton’s mother). The shot demanded that a black Prius drive toward a red Isuzu Rodeo and stop short, nose-to-nose. Nichols wanted to show the cars in profile. There was just one problem: To get the shot, the only place for the camera was in a bog nearly 4 feet deep. “There’s one right place to put the camera. I’m a big believer in that,” he said. “You’d think you could put it anywhere. Nope. It’s like a diet of the mind.”</p>
+  <p>So Steadicam operator Matt Petrosky and first assistant cameraman David Regan went out on the water in a flat-­bottomed boat—a luxury, all the indie veterans there agreed, possible only because of Warner Bros.’ largesse. They pushed with long poles to float the camera and themselves into position. But the boat kept wobbling, threatening to ruin the shot.</p>
+  <figure class="image image-style-align-center">
+     <img src="https://www.wired.com/wp-content/uploads/2016/03/jeffnichols_BTS-929x697.jpg" alt="MIDNIGHT SPECIAL">
+     <figcaption>Nichols discusses a shot on the set of his new sci-fi thriller. BEN ROTHSTEIN/WARNER BROS. PICTURES</figcaption>
+  </figure>
+  <p>“Don’t worry, I have another pair of pants,” Regan said, taking off his shoes and socks and jumping overboard. Rooting himself in the muck, water to his navel, he held the boat steady, saving the day.</p>
+  <p>“Dave, is that water really cold?” Nichols asked, teasing but grateful.</p>
+  <p>“Nossir,” Regan said.</p>
+  <p>“A little cold?” Nichols persisted.</p>
+  <p>“Nossir!”</p>
+  <p>One hallmark of a great director is the ability to inspire loyalty. Shannon has appeared in all five of Nichols’ films; he says he plans never to miss one. Adam Stone, the cinematographer, has shot all five. Will Files, his rerecording mixer, has worked on four and went to Nichols’ wedding. Julie Monroe has edited three. After <i>Midnight Special</i> wrapped, Edgerton immediately signed up to star in Nichols’ next film.</p>
+  <p>But to become that thing our culture so exults in—the bravura director who parlays small, personal films into a place at the helm of a blockbuster—you must be more than likable, or smart, or idea-driven. You must have opportunities to build expertise. In 2000, for example, Nolan made <i>Memento</i> for about $9 million. In 2005 he directed <i>Batman Begins</i>, a $150 million tentpole. But between the two he made (for Warner Bros.) the $46 million <i>Insomnia</i>. It was his midrange training ground.</p>
+  <p>Those kinds of jobs—and those budgets—exist less and less today. A successful $23 million movie like Spike Jonze’s <i>Her</i> may make $47 million worldwide, but it also eats up a release-date slot that could be occupied by a $150 million movie that could make $500 million.</p>
+  <p>So how are talented young directors supposed to learn? Might Hollywood have avoided debacles like last year’s <i>Fantastic Four</i> if it had given its young director, Josh Trank, a shot at something in the middle range after his much-admired, very-low-budget debut feature, <i>Chronicle</i>?</p>
+  <p>Maybe. What’s striking about Nichols is that, after <i>Mud</i>, he created that opportunity for himself. Lots of studios wanted to read Nichols’ next script. He could’ve tried to start a bidding war. Instead, he showed <i>Midnight Special</i> only to Warner Bros.</p>
+  <p>Why Warner Bros., I asked him, and not some other studio? It had a good track record with serious filmmakers: Paul Thomas Anderson, Jonze, Nolan. More important, Nichols had heard great things about its president of worldwide marketing and distribution, Sue Kroll. She could get movies seen. “I never wanted to make movies just for me. I want to make movies that people watch,” Nichols said.</p>
+  <p>Meeting with then–president of production Greg Silverman, he handed over the initial script for <i>Midnight Special</i>. “Look, I want to be a Warner Bros. director,” Nichols told him. “I want this to be a Warner Bros. film. I’m not playing you.” He’d flown from Austin to LA for just the day, for just the one meeting. “I said, ‘I need two things: Michael Shannon and final cut. Well, three things, because: $20 million.’ Then I left.”</p>
+  <p>It was a ballsy roll of the dice. But Silverman’s boss, Warner Bros. president Jeff Robinov, had seen <i>Mud</i> and loved it. Robinov decided he wanted to be in the Jeff Nichols business, and for Nichols that meant the chance at a higher education.</p>
+  <para-box>
+    <figure class="image">
+      <img src="https://www.wired.com/wp-content/uploads/2016/03/jeff_midnight_special_screenshot1.jpg">
+      <figcaption>Joel Edgerton, Shannon, and Kirsten Dunst fight to save the boy played by Jaeden Lieberher in <i>Midnight Special</i>. JIM BRIDGES/ROADSIDE ATTRACTIONS/EVERETT COLLECTION</figcaption>
+    </figure>
+  </para-box>
+  <h3>June 2013 Austin, Texas</h3>
+  <p>For years, Nichols’ wife shouldered most of their family’s financial burden. <i>Shotgun Stories</i> had cost him $49,000. On <i>Take Shelter</i>, he’d been paid just $6,000. Between films he’d temp at an Austin ad agency, but ­Missy’s job in publishing paid most of their expenses. Now, with the Warner Bros. deal in hand, they decided that she could quit and spend more time with their 2-year-old son.</p>
+  <p>At home on the day she gave notice after 19 years at <i>Texas Monthly</i>, Missy was telling her husband about all her tearful good-byes when he glanced down at his iPad. “I just kind of noticed what had popped up. Jeff Robinov, the one that brought me in and set all this up for me, had been fired,” he said. “And I couldn’t tell her. I couldn’t tell her until the next day. I was like, ‘It’s going to be fine.’ She was like, ‘I’ll get my job back.’ I was like, ‘No, no, don’t. It’s going to be great.’ I shit my pants.”</p>
+  <p>Hearing about it even two years later, I couldn’t help but say, “Wow.”</p>
+  <p>“Yeah,” Nichols replied, smiling. “Making movies!”</p>
+  <para-box>
+    <figure class="image image-style-align-left">
+      <img src="https://www.wired.com/wp-content/uploads/2016/02/jeffnichols-MS-004591-660x495.jpg" alt="MIDNIGHT SPECIAL">
+      <figcaption>Michael Shannon as Roy, father of a mysteriously empowered son in Nichols’ upcoming <i>Midnight Special</i>. BEN ROTHSTEIN/WARNER BROS. PICTURES</figcaption>
+    </figure>
+    <figure class="image image-style-align-right">
+      <img src="https://www.wired.com/wp-content/uploads/2016/02/jeffnichols-MS-078701-660x495.jpg" alt="MIDNIGHT SPECIAL">
+      <figcaption>Lieberher plays Alton, a boy whose special abilities make him a target. BEN ROTHSTEIN/WARNER BROS. PICTURES</figcaption>
+    </figure>
+  </para-box>
+  <h3>July 2014 Austin, Texas</h3>
+  <p>Jeff Nichols sat in an ugly office chair, waiting for feedback. Several filmmaker friends had piled into a room with cardboard-covered windows in Nichols’ nondescript production headquarters on East Avenue in Austin to watch <i>Midnight Special</i>. (“Sort of a test screening before the test screening,” he told me.) The effects weren’t done. The music wasn’t locked. He offered the group Dr Pepper (his crutch of choice; he doesn’t drink coffee or smoke cigarettes) and pushed Play.</p>
+  <p>When the lights came back up, Nichols led the group out of his office, past posters for <i>Starman</i> and <i>Close Encounters of the Third Kind</i>, to a conference room. They cracked open beers from a local microbrewery, and talk turned to one very specific criticism: Nichols’ determination to not explain too much. “My feedback would be that I think you’re afraid of exposition where you shouldn’t be,” said Nichols’ old film-school buddy David Gordon Green. “Sometimes you’re holding back, and it’s distracting.”</p>
+  <p>Todd Rohal, another indie director, agreed. “If the characters know more than we do, that’s an interesting mystery,” he said. “But if the movie clearly knows more than we do, then we get frustrated.”</p>
+  <p>This is a central issue for Nichols. He is fascinated by an audience’s “threshold for ambiguity.” With less spelled out, viewers become active participants in the unfolding of the story, he said. “And that’s really cool, if you can get people to basically rewatch scenes in your movie in their heads while it’s still going on. What’s really important is the bigger themes and emotions that you’re trying to get people to access.”</p>
+  <block-quote>
+    <block-quote-body>
+      <p>Nichols is fascinated by people’s threshold for ambiguity—with less spelled out, the audience gets more engaged.</p>
+    </block-quote-body>
+  </block-quote>
+  <p>Like Nichols’ other films, <i>Midnight Special</i>was an opportunity to give himself another creative assignment: Learn to shoot crosscutting action, a technique he has rarely used. The idea is to toggle between two things happening at the same time in different locations. It builds tension and momentum, and it’s a tool for creating suspense. Notably, crosscutting is a hallmark of big-budget action.</p>
+  <p>Nichols, though, was determined to stick to another self-imposed rule. “You keep moving, and any character who can’t move with you is left behind.” By which he meant, sometimes never seen again.</p>
+  <p>Nichols knew that there was a limit to how much confusion any audience could take. And he always bumped right up against it. In each of his previous films, he’d omitted an explanatory scene he’d believed was essential. He’d never regretted it.</p>
+  <p>Case in point, <i>Shotgun Stories</i>: Nichols filmed a scene that explains how Shannon’s character got gruesome shotgun scars on his back. “Deleting that scene was the smartest thing I’ve ever done. The story got better, because the audience began building that story for themselves. And it clarified for me what my approach needs to be. Like, OK: no backstory,” he said. He acknowledged, however, that in removing much of the exposition in <i>Midnight Special</i> he’d “taken that concept possibly too far.”</p>
+  <p>In studio films, loose ends get tied up with bows. Was it really a good idea to always take the shotgun story out of <i>Shotgun Stories</i>? Movies often overdo exposition; people too often launch into monologues about things other characters already know. But cutting all that at the expense of coherence? That didn’t seem like a path to a nine-figure budget.</p>
+  <p>In July 2015, Warner Bros. announced that it was postponing <i>Midnight Special</i>’s release from Thanksgiving to the spring of this year. So much time has passed since the end of production on <i>Midnight Special</i> that Nichols has already directed another indie feature he wrote. He even shot a commercial (his first ever) for Procter &amp; Gamble, in Uruguay, Romania, and Shanghai. It put, he said, “a lot of money” in his pocket— a “financial cushion” that he hopes will allow him to make wise creative decisions without worrying about feeding his family, at least for a while.</p>
+  <p>On the plus side, Warner Bros. honored the deal he had struck with Robinov—same budget, same marketing, and final cut. In February 2015, Nichols finished his first studio film, and even before it has seen the light of day he could name the lessons learned. “I can talk to execs very clearly, very plainly. I don’t get nervous in front of them anymore.” A beat, and then he added: “I think I needed to tick that box before going into the next phase.”</p>
+  <block-quote>
+    <block-quote-body>
+      <p>LEARNING ON THE JOB</p>
+      <p>For each of his films, Jeff Nichols gives himself a set of directorial challenges that he wants to master. In the process, he is learning the skills he will someday need to make a gazillion-dollar blockbuster. Here’s a look at his course work.</p>
+    </block-quote-body>
+  </block-quote>
+  <h3>March 2016 In theaters nationwide</h3>
+  <p>By the time you read this, <i>Midnight Special</i> will have had its world premiere at the Berlin International Film Festival, headed toward a March 18 release in New York and LA and then a six-week rollout in theaters nationwide. You will likely have seen the movie’s evocative poster, which features a boy with glowing eyes, his head poking out E.T.–style from under a blanket, hands aiming a flashlight at a treasured Superman comic (“He’s not like us,” the poster warns). “Listen, I made the film we all want to see,” Nichols said. “I made the film we all sit around saying, ‘God, I wish I could have a film experience like watching <i>Close Encounters</i> again.’” He laughed, knowing full well that he hadn’t made <i>Close Encounters</i>. The thing <i>Midnight Special</i>doesn’t have that Spielberg’s films do is naked sentiment. “I do awe, but I don’t do wonderment.” But the difference between awe and wonderment might also be the difference, he admitted, between a movie that grosses $20 million and one that grosses $1 billion.</p>
+  <block-quote>
+    <block-quote-body>
+      <p><i>Midnight Special’</i>s relatively small budget means that it could never be a <i>John Carter</i>–sized flameout.</p>
+    </block-quote-body>
+  </block-quote>
+  <p>Of course, <i>Midnight Special</i> doesn’t have to sell a billion dollars’ worth of tickets to be a success. Its relatively small budget means that it could never be a <i>John Carter</i>–sized flameout. But how it performs relative to Warner Bros.’ marketing investment (in the $20 million range) will have repercussions. As the releases neared of <i>Midnight Special</i> and Nichols’ other new movie, an independently financed drama called <i>Loving</i>, Nichols seemed to be trying to manage expectations—both for his movies and for himself. “Part of me feels like, ‘OK, if you’re going to do it, Nichols, you gotta do it now: Go get somebody superfamous and get a giant movie, or write one, but make it big and take your shot,’” he said. “But there’s a caveat to that, which is that by June I’ll know if these two films that I spent the last three years of my life making worked on any level.” It’s a grim calculus: director jail after two flops, or success and, what, a <i>Star Wars</i>? Or maybe, he said, he’d try to come up with his own franchise. “Like, why can’t we have more <i>Terminators</i>, more <i>Avatars</i>? Let’s do that! I’ve never just said, ‘Let’s do some world-building.’ Maybe I’ll pull it off, maybe I won’t. But that’s what I want to do.” Shannon thought his friend was in a bit of a bind. “He doesn’t want to put himself into a situation where he’s superfluous. You know? I mean, it’s a unique skill to be able to direct a movie of that size and actually have any sort of auteurness about it,” Shannon said. “But there are a lot of ­people who wind up making them; I couldn’t tell you who the hell they were, or where they came from, or where they’re going. It’s like some name on a poster. I’m pretty sure Jeff doesn’t want to be just the name at the bottom of the poster.”</p>
+  <p>Nichols had two screenings of <i>Midnight Special </i>in front of test audiences in and around Los Angeles. The first didn’t go so well; the second one did. Partially that was because the visual effects were done, but possibly Nichols had picked up a lesson from making it that he had not expected. Even though Warner Bros. had honored his final cut, studio execs had still given him notes. And he had actually taken some of them. They had resonated. Nichols had found a balance between standing up for his vision and being smart enough to act on constructive criticism.</p>
+  <block-quote>
+    <block-quote-body>
+      <h4>RELATED STORIES</h4>
+      <h4><a href="https://www.wired.com/2014/11/nathan-crowley/">Meet the Man Behind the Awesome Sets of The Dark Knight</a></h4>
+      <ul>
+        <li>BY DANIEL ENGBER</li>
+      </ul>
+      <h4><a href="https://www.wired.com/2015/03/drone-filmmaking/">Drones Are About to Change How Directors Make Movies</a></h4>
+      <ul>
+        <li>BY ANGELA WATERCUTTER</li>
+      </ul>
+      <h4><a href="https://www.wired.com/2014/09/cinema-is-evolving/">Data From a Century of Cinema Reveals How Movies Have Evolved</a></h4>
+      <ul>
+        <li>BY GREG MILLER</li>
+      </ul>
+    </block-quote-body>
+  </block-quote>
+  <p>He admitted it had been painful. He doesn’t like to do reshoots or loop in new dialog in post­production. Yet, in the end, Nichols shot one extra scene for <i>Midnight Special</i>. He actually had the money to do it this time, and it enhanced plot clarity. He even rerecorded dialog—five times.</p>
+  <p>In recent months, Nichols has worked with the studio’s marketing team to develop trailers that don’t give away too much but still convey “smart sci-fi.” And he has enjoyed the collaboration. “For once, I’m not the only excited person on a phone call,” Nichols said.</p>
+  <p>For what it’s worth, I’ve seen <i>Midnight Special</i>. That sound mix he’d worked so hard on? It paid off—the thrumming engine of the getaway car, a 1971 Chevelle, was nothing short of luscious. Several scenes were so haunting that I found myself rewatching them in my head, just as Nichols had hoped. The effects were great; awe was engendered. But more than that, I was struck—or should I say leveled?—by the film’s exploration of parental devotion and the need, ultimately, to let your child go. In other words, yes, I cried in a Jeff Nichols sci-fi movie. Experiential? Check. Moving? Very. A master class in blockbusting? That’ll be up to him.</p>
+</div>
+<div id="preview">
 
-	<p>This is an instance of the <a href="https://ckeditor.com/docs/ckeditor5/latest/builds/guides/overview.html#classic-editor">classic editor build</a>.</p>
-
-	<figure class="image">
-		<img src="../tests/manual/sample.jpg" alt="Autumn fields" />
-	</figure>
-
-	<p>You can use this sample to validate whether your <a href="https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/custom-builds.html">custom build</a> works fine.</p>
 </div>
 
 <script src="../build/ckeditor.js"></script>
-<script>
-	ClassicEditor.create( document.querySelector( '#editor' ) )
-		.then( editor => {
-			window.editor = editor;
-		} )
-		.catch( err => {
-			console.error( err.stack );
-		} );
-</script>
 
 </body>
 </html>

--- a/src/blockQuote/blockQuote.js
+++ b/src/blockQuote/blockQuote.js
@@ -1,0 +1,12 @@
+import BlockQuoteEditing from './blockQuoteEditing';
+import BlockQuoteToolbar from './ui/blockQuoteToolbar';
+import InsertBlockQuoteButton from './ui/insertBlockQuoteButton';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+import './theme/blockquote.css';
+
+export default class BlockQuote extends Plugin {
+	static get requires() {
+		return [ BlockQuoteEditing, InsertBlockQuoteButton, BlockQuoteToolbar ];
+	}
+}

--- a/src/blockQuote/blockQuoteEditing.js
+++ b/src/blockQuote/blockQuoteEditing.js
@@ -1,0 +1,161 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import { toWidget, toWidgetEditable } from '@ckeditor/ckeditor5-widget/src/utils';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
+
+import InsertBlockQuoteCommand from './commands/insertBlockQuote';
+import UpdateBlockQuotePositionCommand from './commands/updateBlockQuotePosition';
+import Components from './ui/components';
+import { define } from '../web-component';
+
+export default class BlockQuoteEditing extends Plugin {
+	static get requires() {
+		return [ Widget ];
+	}
+
+	init() {
+		console.log( 'init custom blockquote editing plugin' );
+
+		this._defineSchema();
+		this._defineConverters();
+
+		define( 'block-quote', Components.BlockQuote );
+		define( 'block-quote-body', Components.BlockQuoteBody );
+		define( 'block-quote-credit', Components.BlockQuoteCredit );
+
+		this.editor.commands.add( 'insertBlockQuote', new InsertBlockQuoteCommand( this.editor ) );
+		this.editor.commands.add( 'blockQuotePosition', new UpdateBlockQuotePositionCommand( this.editor ) );
+	}
+
+	_defineSchema() {
+		const schema = this.editor.model.schema;
+
+		schema.register( 'blockQuote', {
+			isObject: true,
+			allowWhere: '$block',
+			allowAttributes: [ 'position' ]
+		} );
+
+		schema.register( 'blockQuoteBody', {
+			isLimit: true,
+			allowIn: 'blockQuote',
+			allowContentOf: '$root'
+		} );
+
+		schema.register( 'blockQuoteCredit', {
+			isLimit: true,
+			allowIn: 'blockQuote',
+			allowContentOf: '$root'
+		} );
+
+		schema.addChildCheck( ( context, childDefinition ) => {
+			if ( context.endsWith( 'blockQuote' ) && childDefinition.name == 'blockQuote' ) {
+				return false;
+			}
+		} );
+	}
+
+	_defineConverters() {
+		const conversion = this.editor.conversion;
+
+		conversion.for( 'upcast' ).elementToElement( {
+			model: ( viewElement, modelWriter ) => {
+				const blockQuote = modelWriter.createElement( 'blockQuote' );
+
+				if ( !Array.from( viewElement.getChildren() ).find( element => element.name === 'block-quote-credit' ) ) {
+					const blockQuoteCredit = modelWriter.createElement( 'blockQuoteCredit' );
+					modelWriter.insert( modelWriter.createElement( 'paragraph' ), blockQuoteCredit );
+					modelWriter.append( blockQuoteCredit, blockQuote );
+				}
+
+				return blockQuote;
+			},
+			view: {
+				name: 'block-quote'
+			}
+		} ).attributeToAttribute( {
+			model: 'position',
+			view: {
+				name: 'block-quote',
+				key: 'position'
+			}
+		} );
+
+		conversion.for( 'dataDowncast' ).elementToElement( {
+			model: 'blockQuote',
+			view: ( model, viewWriter ) => {
+				return viewWriter.createContainerElement( 'block-quote' );
+			}
+		} ).attributeToAttribute( {
+			model: 'position',
+			view: 'position'
+		} );
+
+		conversion.for( 'editingDowncast' ).elementToElement( {
+			model: 'blockQuote',
+			view: ( _, viewWriter ) => {
+				const component = viewWriter.createContainerElement( 'block-quote' );
+				return toWidget( component, viewWriter );
+			}
+		} ).attributeToAttribute( {
+			model: 'position',
+			view: 'position',
+			converterPriority: 'low'
+		} );
+
+		conversion.for( 'upcast' ).elementToElement( {
+			model: 'blockQuoteBody',
+			view: {
+				name: 'block-quote-body'
+			}
+		} );
+
+		conversion.for( 'dataDowncast' ).elementToElement( {
+			model: 'blockQuoteBody',
+			view: {
+				name: 'block-quote-body'
+			}
+		} );
+
+		conversion.for( 'editingDowncast' ).elementToElement( {
+			model: 'blockQuoteBody',
+			view: ( modelElement, viewWriter ) => {
+				const body = viewWriter.createEditableElement(
+					'block-quote-body',
+					{
+						slot: 'block-quote-body'
+					}
+				);
+
+				return toWidgetEditable( body, viewWriter );
+			}
+		} );
+
+		conversion.for( 'upcast' ).elementToElement( {
+			model: 'blockQuoteCredit',
+			view: {
+				name: 'block-quote-credit'
+			}
+		} );
+
+		conversion.for( 'dataDowncast' ).elementToElement( {
+			model: 'blockQuoteCredit',
+			view: {
+				name: 'block-quote-credit'
+			}
+		} );
+
+		conversion.for( 'editingDowncast' ).elementToElement( {
+			model: 'blockQuoteCredit',
+			view: ( modelElement, viewWriter ) => {
+				const credit = viewWriter.createEditableElement(
+					'block-quote-credit',
+					{
+						slot: 'block-quote-credit'
+					}
+				);
+
+				return toWidgetEditable( credit, viewWriter );
+			}
+		} );
+	}
+}

--- a/src/blockQuote/commands/insertBlockQuote.js
+++ b/src/blockQuote/commands/insertBlockQuote.js
@@ -1,0 +1,30 @@
+import Command from '@ckeditor/ckeditor5-core/src/command';
+
+function createBlockQuote( writer ) {
+	const blockQuote = writer.createElement( 'blockQuote' );
+	const blockQuoteBody = writer.createElement( 'blockQuoteBody' );
+	const blockQuoteCredit = writer.createElement( 'blockQuoteCredit' );
+
+	writer.insert( writer.createElement( 'paragraph' ), blockQuoteBody );
+	writer.insert( writer.createElement( 'paragraph' ), blockQuoteCredit );
+
+	writer.append( blockQuoteBody, blockQuote );
+	writer.append( blockQuoteCredit, blockQuote );
+	return blockQuote;
+}
+
+export default class InsertBlockQuoteCommand extends Command {
+	execute() {
+		this.editor.model.change( writer => {
+			this.editor.model.insertContent( createBlockQuote( writer ) );
+		} );
+	}
+
+	refresh() {
+		const model = this.editor.model;
+		const selection = model.document.selection;
+		const allowedParent = model.schema.findAllowedParent( selection.getFirstPosition(), 'blockQuote' );
+
+		this.isEnabled = !!allowedParent;
+	}
+}

--- a/src/blockQuote/commands/updateBlockQuotePosition.js
+++ b/src/blockQuote/commands/updateBlockQuotePosition.js
@@ -1,0 +1,27 @@
+import Command from '@ckeditor/ckeditor5-core/src/command';
+import { getBlockQuoteModelFromSelection } from '../utils';
+
+export default class UpdateBlockquotePositionCommand extends Command {
+	refresh() {
+		const model = this.editor.model;
+		const blockQuote = getBlockQuoteModelFromSelection( model.document.selection );
+
+		this.isEnabled = !!blockQuote;
+		this.value = blockQuote && blockQuote.getAttribute( 'position' );
+	}
+
+	execute( options ) {
+		const position = options.value;
+
+		const model = this.editor.model;
+		const blockQuote = getBlockQuoteModelFromSelection( model.document.selection );
+
+		model.change( writer => {
+			if ( !position ) {
+				writer.removeAttribute( 'position', blockQuote );
+			} else {
+				writer.setAttribute( 'position', position, blockQuote );
+			}
+		} );
+	}
+}

--- a/src/blockQuote/theme/blockquote.css
+++ b/src/blockQuote/theme/blockquote.css
@@ -1,0 +1,10 @@
+block-quote[position="inset-left"] {
+  float: left;
+  max-width: 45%;
+  margin-right: 5%;
+}
+block-quote[position="inset-right"] {
+  float: right;
+  max-width: 45%;
+  margin-left: 5%;
+}

--- a/src/blockQuote/ui/blockQuoteToolbar.js
+++ b/src/blockQuote/ui/blockQuoteToolbar.js
@@ -1,0 +1,79 @@
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import WidgetToolbarRepository from '@ckeditor/ckeditor5-widget/src/widgettoolbarrepository';
+import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+
+import fullWidthIcon from '@ckeditor/ckeditor5-core/theme/icons/object-full-width.svg';
+import leftIcon from '@ckeditor/ckeditor5-core/theme/icons/object-left.svg';
+import rightIcon from '@ckeditor/ckeditor5-core/theme/icons/object-right.svg';
+
+import { getBlockQuoteElementFromSelection } from '../utils';
+
+const DEFAULT_POSITIONS = {
+	'inset-left': {
+		name: 'inset-left',
+		title: 'Positioned inset left',
+		icon: leftIcon
+	},
+	'full-width': {
+		name: 'full-width',
+		title: 'Positioned full width',
+		icon: fullWidthIcon
+	},
+	'inset-right': {
+		name: 'inset-right',
+		title: 'Positioned inset right',
+		icon: rightIcon
+	}
+};
+
+export default class BlockQuoteToolbar extends Plugin {
+	static get requires() {
+		return [ WidgetToolbarRepository ];
+	}
+
+	static get pluginName() {
+		return 'BlockQuoteToolbar';
+	}
+
+	_getPositionOption( position ) {
+		if ( typeof position === 'string' ) {
+			return DEFAULT_POSITIONS[ position ] || {};
+		}
+
+		return position;
+	}
+
+	init() {
+		const editor = this.editor;
+		const positions = editor.config.get( 'blockQuote.positions' );
+		positions.map( this._getPositionOption ).forEach( position => {
+			editor.ui.componentFactory.add( `blockQuotePosition:${ position.name }`, locale => {
+				const command = editor.commands.get( 'blockQuotePosition' );
+				const view = new ButtonView( locale );
+
+				view.set( {
+					label: position.title,
+					icon: position.icon,
+					tooltip: true
+				} );
+
+				view.bind( 'isEnabled' ).to( command, 'isEnabled' );
+				view.bind( 'isOn' ).to( command, 'value', value => value === position.name );
+
+				this.listenTo( view, 'execute', () => editor.execute( 'blockQuotePosition', { value: position.name } ) );
+				return view;
+			} );
+		} );
+	}
+
+	afterInit() {
+		const editor = this.editor;
+		const widgetToolbarRepository = editor.plugins.get( WidgetToolbarRepository );
+
+		widgetToolbarRepository.register( 'blockQuote', {
+			items: ( editor.config.get( 'blockQuote.positions' ) || [] ).map( position => `blockQuotePosition:${ position }` ),
+			getRelatedElement: getBlockQuoteElementFromSelection
+		} );
+	}
+}

--- a/src/blockQuote/ui/components.js
+++ b/src/blockQuote/ui/components.js
@@ -1,0 +1,69 @@
+
+import Component from '../../web-component';
+
+class BlockQuote extends Component {
+	updatePosition( elem ) {
+		const shadow = elem.shadowRoot;
+		const className = `block-quote ${ elem.getAttribute( 'position' ) || '' }`.trim();
+		shadow.querySelector( 'section' ).className = className;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.updatePosition( this );
+	}
+
+	attributeChangedCallback( name ) {
+		if ( name === 'position' ) {
+			this.updatePosition( this );
+		}
+	}
+}
+
+BlockQuote.observedAttributes = [ 'position' ];
+
+BlockQuote.template = `
+  <section class='block-quote'>
+    <slot name='block-quote-body'></slot>
+    <slot name='block-quote-credit'></slot>
+  </section>
+`;
+
+BlockQuote.style = '';
+
+class BlockQuoteBody extends Component {}
+
+BlockQuoteBody.template = `
+  <div class='block-quote-body' placeholder='Quote body'>
+    <slot></slot>
+  </div>
+`;
+
+BlockQuoteBody.style = `
+  :host .block-quote-body {
+    margin-left: 1em;
+    border-left: 2px solid black;
+    padding-left: 1em;
+  }
+`;
+
+class BlockQuoteCredit extends Component {}
+
+BlockQuoteCredit.template = `
+  <div class='block-quote-credit'>
+    <slot></slot>
+  </div>
+`;
+
+BlockQuoteCredit.style = `
+  :host .block-quote-credit {
+    font-style: italic;
+    text-align: right;
+  }
+`;
+
+export default {
+	BlockQuote,
+	BlockQuoteBody,
+	BlockQuoteCredit
+};

--- a/src/blockQuote/ui/insertBlockQuoteButton.js
+++ b/src/blockQuote/ui/insertBlockQuoteButton.js
@@ -1,0 +1,24 @@
+import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+export default class InsertBlockQuoteButton extends Plugin {
+	init() {
+		console.log( 'init custom blockquote ui plugin' );
+
+		const editor = this.editor;
+		editor.ui.componentFactory.add( 'blockQuote', locale => {
+			const command = editor.commands.get( 'insertBlockQuote' );
+			const button = new ButtonView( locale );
+
+			button.set( {
+				label: editor.t( 'Blockquote' ),
+				withText: true,
+				tooltip: true
+			} );
+			button.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
+			this.listenTo( button, 'execute', () => editor.execute( 'insertBlockQuote' ) );
+
+			return button;
+		} );
+	}
+}

--- a/src/blockQuote/utils.js
+++ b/src/blockQuote/utils.js
@@ -1,0 +1,23 @@
+export function getBlockQuoteModelFromSelection( selection ) {
+	const blocks = Array.from( selection.getSelectedBlocks() );
+
+	if ( blocks.length === 1 ) {
+		let model = blocks[ 0 ];
+		while ( model != null && model.name !== 'blockQuote' ) {
+			model = model.parent;
+		}
+
+		return model;
+	}
+
+	return null;
+}
+
+export function getBlockQuoteElementFromSelection( selection ) {
+	let element = selection.editableElement;
+	while ( element !== null && element.name !== 'block-quote' ) {
+		element = element.parent;
+	}
+
+	return element;
+}

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -11,11 +11,12 @@ import UploadAdapter from '@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapte
 import Autoformat from '@ckeditor/ckeditor5-autoformat/src/autoformat';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
-import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote';
+// import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote';
 import CKFinder from '@ckeditor/ckeditor5-ckfinder/src/ckfinder';
 import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 import Image from '@ckeditor/ckeditor5-image/src/image';
+import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
 import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption';
 import ImageStyle from '@ckeditor/ckeditor5-image/src/imagestyle';
 import ImageToolbar from '@ckeditor/ckeditor5-image/src/imagetoolbar';
@@ -28,6 +29,9 @@ import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefrom
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar';
 
+// import ParaBox from './paraBox/paraBox';
+import BlockQuote from './blockQuote/blockQuote';
+
 export default class ClassicEditor extends ClassicEditorBase {}
 
 // Plugins to include in the build.
@@ -37,7 +41,7 @@ ClassicEditor.builtinPlugins = [
 	Autoformat,
 	Bold,
 	Italic,
-	BlockQuote,
+	// BlockQuote,
 	CKFinder,
 	EasyImage,
 	Heading,
@@ -52,7 +56,11 @@ ClassicEditor.builtinPlugins = [
 	Paragraph,
 	PasteFromOffice,
 	Table,
-	TableToolbar
+	TableToolbar,
+
+	// Custom plugins
+	// ParaBox,
+	BlockQuote
 ];
 
 // Editor configuration.
@@ -67,17 +75,34 @@ ClassicEditor.defaultConfig = {
 			'bulletedList',
 			'numberedList',
 			'imageUpload',
-			'blockQuote',
+			// 'blockQuote',
 			'insertTable',
 			'mediaEmbed',
 			'undo',
-			'redo'
+			'redo',
+			'|',
+			'blockQuote'
+		]
+	},
+	blockQuote: {
+		positions: [
+			'inset-left',
+			'full-width',
+			'inset-right'
 		]
 	},
 	image: {
+		styles: [
+			'full',
+			'alignCenter',
+			'alignLeft',
+			'alignRight'
+		],
 		toolbar: [
 			'imageStyle:full',
-			'imageStyle:side',
+			'imageStyle:alignLeft',
+			'imageStyle:alignCenter',
+			'imageStyle:alignRight',
 			'|',
 			'imageTextAlternative'
 		]
@@ -92,3 +117,13 @@ ClassicEditor.defaultConfig = {
 	// This value must be kept in sync with the language defined in webpack.config.js.
 	language: 'en'
 };
+
+ClassicEditor.create( document.querySelector( '#editor' ) )
+	.then( editor => {
+		window.editor = editor;
+		CKEditorInspector.attach( 'editor', editor );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	}
+	);

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -81,7 +81,8 @@ ClassicEditor.defaultConfig = {
 			'undo',
 			'redo',
 			'|',
-			'blockQuote'
+			'blockQuote',
+			'paraBox'
 		]
 	},
 	blockQuote: {

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -29,7 +29,7 @@ import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefrom
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar';
 
-// import ParaBox from './paraBox/paraBox';
+import ParaBox from './paraBox/paraBox';
 import BlockQuote from './blockQuote/blockQuote';
 
 export default class ClassicEditor extends ClassicEditorBase {}
@@ -59,7 +59,7 @@ ClassicEditor.builtinPlugins = [
 	TableToolbar,
 
 	// Custom plugins
-	// ParaBox,
+	ParaBox,
 	BlockQuote
 ];
 

--- a/src/paraBox/commands/insertParaBox.js
+++ b/src/paraBox/commands/insertParaBox.js
@@ -1,0 +1,19 @@
+import Command from '@ckeditor/ckeditor5-core/src/command';
+
+export default class InsertParaBoxCommand extends Command {
+	execute() {
+		this.editor.model.change( writer => {
+			const paraBox = writer.createElement( 'paraBox' );
+			writer.insert( writer.createElement( 'paragraph' ), paraBox );
+			this.editor.model.insertContent( paraBox );
+		} );
+	}
+
+	refresh() {
+		const model = this.editor.model;
+		const selection = model.document.selection;
+		const allowedParent = model.schema.findAllowedParent( selection.getFirstPosition(), 'paraBox' );
+
+		this.isEnabled = !!allowedParent;
+	}
+}

--- a/src/paraBox/paraBox.js
+++ b/src/paraBox/paraBox.js
@@ -1,0 +1,9 @@
+import ParaBoxEditing from './paraBoxEditing';
+import InsertParaBoxButton from './ui/insertParaBoxButton';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+export default class ParaBox extends Plugin {
+	static get requires() {
+		return [ ParaBoxEditing, InsertParaBoxButton ];
+	}
+}

--- a/src/paraBox/paraBoxEditing.js
+++ b/src/paraBox/paraBoxEditing.js
@@ -1,0 +1,64 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import { toWidget, toWidgetEditable } from '@ckeditor/ckeditor5-widget/src/utils';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
+
+import InsertParaBoxCommand from './commands/insertParaBox';
+import Components from './ui/components';
+import { define } from '../web-component';
+
+export default class ParaBoxEditing extends Plugin {
+	static get requires() {
+		return [ Widget ];
+	}
+
+	init() {
+		console.log( 'init Parallax Box editing plugin' );
+
+		this._defineSchema();
+		this._defineConverters();
+		define( 'para-box', Components.ParaBox );
+		this.editor.commands.add( 'insertParaBox', new InsertParaBoxCommand( this.editor ) );
+	}
+
+	_defineSchema() {
+		const schema = this.editor.model.schema;
+
+		schema.register( 'paraBox', {
+			isObject: true,
+			allowWhere: '$block',
+			allowContentOf: '$root'
+		} );
+
+		schema.addChildCheck( ( context, childDefinition ) => {
+			if ( context.endsWith( 'paraBoxBody' ) && childDefinition.name == 'paraBox' ) {
+				return false;
+			}
+		} );
+	}
+
+	_defineConverters() {
+		const conversion = this.editor.conversion;
+
+		conversion.for( 'upcast' ).elementToElement( {
+			model: 'paraBox',
+			view: {
+				name: 'para-box'
+			}
+		} );
+
+		conversion.for( 'dataDowncast' ).elementToElement( {
+			model: 'paraBox',
+			view: {
+				name: 'para-box'
+			}
+		} );
+
+		conversion.for( 'editingDowncast' ).elementToElement( {
+			model: 'paraBox',
+			view: ( _, viewWriter ) => {
+				const component = viewWriter.createEditableElement( 'para-box' );
+				return toWidgetEditable( toWidget( component, viewWriter ), viewWriter );
+			}
+		} );
+	}
+}

--- a/src/paraBox/ui/components.js
+++ b/src/paraBox/ui/components.js
@@ -1,0 +1,17 @@
+import Component from '../../web-component';
+
+class ParaBox extends Component {}
+
+ParaBox.template = `
+  <section class='para-box'>
+    <div class='para-box-body'>
+      <slot></slot>
+    </div>
+  </section>
+`;
+
+ParaBox.style = '';
+
+export default {
+	ParaBox
+};

--- a/src/paraBox/ui/insertParaBoxButton.js
+++ b/src/paraBox/ui/insertParaBoxButton.js
@@ -1,0 +1,24 @@
+import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+export default class InsertParaBoxButton extends Plugin {
+	init() {
+		console.log( 'init custom parabox ui plugin' );
+
+		const editor = this.editor;
+		editor.ui.componentFactory.add( 'paraBox', locale => {
+			const command = editor.commands.get( 'insertParaBox' );
+			const button = new ButtonView( locale );
+
+			button.set( {
+				label: editor.t( 'ParaBox' ),
+				withText: true,
+				tooltip: true
+			} );
+			button.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
+			this.listenTo( button, 'execute', () => editor.execute( 'insertParaBox' ) );
+
+			return button;
+		} );
+	}
+}

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -1,0 +1,108 @@
+function getEventNameAndElement( element, definition ) {
+	const [ eventName, ...selectors ] = definition.split( ' ' );
+	const selector = selectors.join( ' ' );
+	if ( selector === 'document' ) {
+		return { eventName, element: document };
+	}
+	else if ( selector === 'window' ) {
+		return { eventName, element: window };
+	}
+	else if ( selector === '' ) {
+		return { eventName, element };
+	}
+	else {
+		let querySelector;
+		if ( element.shadowRoot ) {
+			querySelector = element.shadowRoot.querySelector( selector ) || element.querySelector( selector );
+		}
+		else {
+			querySelector = element.querySelector( selector );
+		}
+		return { eventName, element: querySelector };
+	}
+}
+export function define( name, component ) {
+	if ( !window.customElements.get( name ) ) {
+		window.customElements.define( name, component );
+	}
+	return component;
+}
+
+/**
+* The events mixin is a Backbone-flavored event management system
+* that automatically sets up and tears down events on web components
+* when they are connected and disconnected from a document.
+*
+* To use this, include the events mixin on your web component,
+* and add a static property called `events` that provides a lookup
+* table to the events that you'd like to attach to your component.
+*
+* ```js
+* import events from './mixins/events';
+*
+* export default TextSelection extends events(HTMLElement) {
+*   static events = {
+*     'selectionchange document': 'selectedTextDidChange',
+*     'mousedown': 'willSelectText',
+*     'mouseup': 'didSelectText'
+*   };
+* }
+* ```
+*
+* The selectors for `window` and `document` will select only those
+* elements; all other selectors will lookup in the scope of the web
+* component. This allows components to look at events like scrolling,
+* resizing, and selection events without using `addEventListener` /
+* `removeEventListener`.
+*/
+export default class Component extends HTMLElement {
+	static get compiledTemplate() {
+		if ( !this.compiledElement ) {
+			this.compiledElement = document.createElement( 'template' );
+			const scopedStyles = this.style;
+			let html = this.template;
+			if ( scopedStyles ) {
+				html = `<style>${ scopedStyles }</style>${ html }`;
+			}
+			this.compiledElement.innerHTML = html;
+		}
+		return this.compiledElement;
+	}
+	constructor() {
+		super();
+		this.eventHandlers = {};
+		const ComponentClass = this.constructor;
+		const shadowRoot = this.attachShadow( { mode: 'open' } );
+		shadowRoot.appendChild( ComponentClass.compiledTemplate.content.cloneNode( true ) );
+	}
+	connectedCallback() {
+		const ComponentClass = this.constructor;
+		const events = ComponentClass.events || {};
+		Object.keys( events ).forEach( definition => {
+			const { eventName, element } = getEventNameAndElement( this, definition );
+			const method = events[ definition ];
+			this.eventHandlers[ definition ] = evt => {
+				if ( typeof method === 'string' ) {
+					if ( this[ method ] ) {
+						return this[ method ]( evt );
+					}
+					else {
+						throw new Error( `😭 \`${ method }\` was not defined on ${ this.tagName }- did you misspell  or forget to add it?` );
+					}
+				}
+				else {
+					return method.call( this, evt );
+				}
+			};
+			element.addEventListener( eventName, this.eventHandlers[ definition ] );
+		} );
+	}
+
+	disconnectedCallback() {
+		Object.keys( this.eventHandlers ).forEach( definition => {
+			const { eventName, element } = getEventNameAndElement( this, definition );
+			element.removeEventListener( eventName, this.eventHandlers[ definition ] );
+		} );
+		this.eventHandlers = {};
+	}
+}


### PR DESCRIPTION
This is a PR showing adding two custom plugins: a `parabox` container and a custom `blockquote`. The custom `blockquote` has the data model
```
<block-quote>
  <block-quote-body>...</block-quote-body>
  <block-quote-credit>...</block-quote-credit>
</block-quote>
```
and is rendered via custom HTML (ie a web component).
The plugin includes a button to insert a new blockquote and a floating toolbar to adjust its position as `inset-left`, `full-width`, or `inset-right`.

The custom `parabox` has the data model
```
<para-box>
```
and includes an insert button.

This PR also updates the sample text to include these new elements illustrate the upcast converters, and adds the developer tools to the build.
